### PR TITLE
chore: add default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,7 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
+# The @googleapis/yoshi-python is the default owner for changes in this repo
+*               @googleapis/yoshi-python
+
 /samples/**/*.py  @telpirion @sirtorry @GoogleCloudPlatform/python-samples-owners


### PR DESCRIPTION
Add a default () codeowner to enforce required codeowner review on PRs.