### PR TITLE
fix: Add she-bangs to scripts so they can be executed directly

### DIFF
--- a/scripts/fixup_speech_v1_keywords.py
+++ b/scripts/fixup_speech_v1_keywords.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # -*- coding: utf-8 -*-
 
 # Copyright 2020 Google LLC

--- a/scripts/fixup_speech_v1p1beta1_keywords.py
+++ b/scripts/fixup_speech_v1p1beta1_keywords.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # -*- coding: utf-8 -*-
 
 # Copyright 2020 Google LLC


### PR DESCRIPTION
Otherwise you have to prefix the commands with `python3`, if you don't the
scripts will be executed as shell scripts and they won't have anywhere near
the same impact.

I haven't made any issue for this since it doesn't seem to be something that
requires a lot of discussion about how to implement it.