### PR TITLE
docs(samples): remove io dependency in transcribe samples

### DIFF
--- a/samples/snippets/transcribe_async.py
+++ b/samples/snippets/transcribe_async.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google Cloud Speech API sample application using the REST API for async
+batch processing.
+Example usage:
+    python transcribe_async.py resources/audio.raw
+    python transcribe_async.py gs://cloud-samples-tests/speech/vr.flac
+"""
+
+import argparse
+import io
+
+
+# [START speech_transcribe_async]
+def transcribe_file(speech_file):
+    """Transcribe the given audio file asynchronously."""
+    from google.cloud import speech
+
+    client = speech.SpeechClient()
+
+    # [START speech_python_migration_async_request]
+    with io.open(speech_file, "rb") as audio_file:
+        content = audio_file.read()
+
+    """
+     Note that transcription is limited to a 60 seconds audio file.
+     Use a GCS file for audio longer than 1 minute.
+    """
+    audio = speech.RecognitionAudio(content=content)
+
+    config = speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+        sample_rate_hertz=16000,
+        language_code="en-US",
+    )
+
+    # [START speech_python_migration_async_response]
+
+    operation = client.long_running_recognize(config=config, audio=audio)
+    # [END speech_python_migration_async_request]
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=90)
+
+    # Each result is for a consecutive portion of the audio. Iterate through
+    # them to get the transcripts for the entire audio file.
+    for result in response.results:
+        # The first alternative is the most likely one for this portion.
+        print(u"Transcript: {}".format(result.alternatives[0].transcript))
+        print("Confidence: {}".format(result.alternatives[0].confidence))
+    # [END speech_python_migration_async_response]
+
+
+# [END speech_transcribe_async]
+
+
+# [START speech_transcribe_async_gcs]
+def transcribe_gcs(gcs_uri):
+    """Asynchronously transcribes the audio file specified by the gcs_uri."""
+    from google.cloud import speech
+
+    client = speech.SpeechClient()
+
+    audio = speech.RecognitionAudio(uri=gcs_uri)
+    config = speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.FLAC,
+        sample_rate_hertz=16000,
+        language_code="en-US",
+    )
+
+    operation = client.long_running_recognize(config=config, audio=audio)
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=90)
+
+    # Each result is for a consecutive portion of the audio. Iterate through
+    # them to get the transcripts for the entire audio file.
+    for result in response.results:
+        # The first alternative is the most likely one for this portion.
+        print(u"Transcript: {}".format(result.alternatives[0].transcript))
+        print("Confidence: {}".format(result.alternatives[0].confidence))
+
+
+# [END speech_transcribe_async_gcs]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("path", help="File or GCS path for audio file to be recognized")
+    args = parser.parse_args()
+    if args.path.startswith("gs://"):
+        transcribe_gcs(args.path)
+    else:
+        transcribe_file(args.path)

--- a/samples/snippets/transcribe_async_file.py
+++ b/samples/snippets/transcribe_async_file.py
@@ -14,14 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Google Cloud Speech API sample application using the REST API for async
+"""Google Cloud Speech API sample application using gRPC for async
 batch processing.
-Example usage:
-    python transcribe_async.py resources/audio.raw
-    python transcribe_async.py gs://cloud-samples-tests/speech/vr.flac
 """
-
-import argparse
 
 
 # [START speech_transcribe_async]
@@ -65,12 +60,3 @@ def transcribe_file(speech_file):
 
 
 # [END speech_transcribe_async]
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-    parser.add_argument("--path", help="File or GCS path for audio file to be recognized")
-    args = parser.parse_args()
-    transcribe_file(args.path)

--- a/samples/snippets/transcribe_async_file.py
+++ b/samples/snippets/transcribe_async_file.py
@@ -22,7 +22,6 @@ Example usage:
 """
 
 import argparse
-import io
 
 
 # [START speech_transcribe_async]
@@ -33,7 +32,7 @@ def transcribe_file(speech_file):
     client = speech.SpeechClient()
 
     # [START speech_python_migration_async_request]
-    with io.open(speech_file, "rb") as audio_file:
+    with open(speech_file, "rb") as audio_file:
         content = audio_file.read()
 
     """
@@ -68,43 +67,10 @@ def transcribe_file(speech_file):
 # [END speech_transcribe_async]
 
 
-# [START speech_transcribe_async_gcs]
-def transcribe_gcs(gcs_uri):
-    """Asynchronously transcribes the audio file specified by the gcs_uri."""
-    from google.cloud import speech
-
-    client = speech.SpeechClient()
-
-    audio = speech.RecognitionAudio(uri=gcs_uri)
-    config = speech.RecognitionConfig(
-        encoding=speech.RecognitionConfig.AudioEncoding.FLAC,
-        sample_rate_hertz=16000,
-        language_code="en-US",
-    )
-
-    operation = client.long_running_recognize(config=config, audio=audio)
-
-    print("Waiting for operation to complete...")
-    response = operation.result(timeout=90)
-
-    # Each result is for a consecutive portion of the audio. Iterate through
-    # them to get the transcripts for the entire audio file.
-    for result in response.results:
-        # The first alternative is the most likely one for this portion.
-        print(u"Transcript: {}".format(result.alternatives[0].transcript))
-        print("Confidence: {}".format(result.alternatives[0].confidence))
-
-
-# [END speech_transcribe_async_gcs]
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("path", help="File or GCS path for audio file to be recognized")
+    parser.add_argument("--path", help="File or GCS path for audio file to be recognized")
     args = parser.parse_args()
-    if args.path.startswith("gs://"):
-        transcribe_gcs(args.path)
-    else:
-        transcribe_file(args.path)
+    transcribe_file(args.path)

--- a/samples/snippets/transcribe_async_file.py
+++ b/samples/snippets/transcribe_async_file.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2017 Google Inc. All Rights Reserved.
+# Copyright 2021 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/transcribe_async_file.py
+++ b/samples/snippets/transcribe_async_file.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2021 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Google Cloud Speech API sample application using gRPC for async
+"""Google Cloud Speech-to-Text sample application using gRPC for async
 batch processing.
 """
 

--- a/samples/snippets/transcribe_async_file_test.py
+++ b/samples/snippets/transcribe_async_file_test.py
@@ -1,0 +1,26 @@
+# Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+import transcribe_async_file
+
+RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+
+
+def test_transcribe(capsys):
+    transcribe_async_file.transcribe_file(os.path.join(RESOURCES, "audio.raw"))
+    out, err = capsys.readouterr()
+
+    assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)

--- a/samples/snippets/transcribe_async_file_test.py
+++ b/samples/snippets/transcribe_async_file_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2021, Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/samples/snippets/transcribe_async_gcs.py
+++ b/samples/snippets/transcribe_async_gcs.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # Copyright 2021 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Google Cloud Speech API sample application using the gRPC for async
+"""Google Cloud Speech-to-Text sample application using the gRPC for async
 batch processing.
 """
 

--- a/samples/snippets/transcribe_async_gcs.py
+++ b/samples/snippets/transcribe_async_gcs.py
@@ -14,14 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Google Cloud Speech API sample application using the REST API for async
+"""Google Cloud Speech API sample application using the gRPC for async
 batch processing.
-Example usage:
-    python transcribe_async.py resources/audio.raw
-    python transcribe_async.py gs://cloud-samples-tests/speech/vr.flac
 """
-
-import argparse
 
 
 # [START speech_transcribe_async_gcs]
@@ -50,12 +45,3 @@ def transcribe_gcs(gcs_uri):
         print(u"Transcript: {}".format(result.alternatives[0].transcript))
         print("Confidence: {}".format(result.alternatives[0].confidence))
 # [END speech_transcribe_async_gcs]
-
-
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-    parser.add_argument("--path", help="File or GCS path for audio file to be recognized")
-    args = parser.parse_args()
-    transcribe_gcs(args.path)

--- a/samples/snippets/transcribe_async_gcs.py
+++ b/samples/snippets/transcribe_async_gcs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2017 Google Inc. All Rights Reserved.
+# Copyright 2021 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/transcribe_async_gcs.py
+++ b/samples/snippets/transcribe_async_gcs.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google Cloud Speech API sample application using the REST API for async
+batch processing.
+Example usage:
+    python transcribe_async.py resources/audio.raw
+    python transcribe_async.py gs://cloud-samples-tests/speech/vr.flac
+"""
+
+import argparse
+
+
+# [START speech_transcribe_async_gcs]
+def transcribe_gcs(gcs_uri):
+    """Asynchronously transcribes the audio file specified by the gcs_uri."""
+    from google.cloud import speech
+
+    client = speech.SpeechClient()
+
+    audio = speech.RecognitionAudio(uri=gcs_uri)
+    config = speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.FLAC,
+        sample_rate_hertz=16000,
+        language_code="en-US",
+    )
+
+    operation = client.long_running_recognize(config=config, audio=audio)
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=90)
+
+    # Each result is for a consecutive portion of the audio. Iterate through
+    # them to get the transcripts for the entire audio file.
+    for result in response.results:
+        # The first alternative is the most likely one for this portion.
+        print(u"Transcript: {}".format(result.alternatives[0].transcript))
+        print("Confidence: {}".format(result.alternatives[0].confidence))
+# [END speech_transcribe_async_gcs]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--path", help="File or GCS path for audio file to be recognized")
+    args = parser.parse_args()
+    transcribe_gcs(args.path)

--- a/samples/snippets/transcribe_async_gcs_test.py
+++ b/samples/snippets/transcribe_async_gcs_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2021, Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -20,7 +20,8 @@ RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 def test_transcribe_gcs(capsys):
-    transcribe_async_gcs.transcribe_gcs("gs://python-docs-samples-tests/speech/audio.flac")
+    gcs_path = "gs://python-docs-samples-tests/speech/audio.flac"
+    transcribe_async_gcs.transcribe_gcs(gcs_path)
     out, err = capsys.readouterr()
 
     assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)

--- a/samples/snippets/transcribe_async_gcs_test.py
+++ b/samples/snippets/transcribe_async_gcs_test.py
@@ -14,20 +14,13 @@
 import os
 import re
 
-import transcribe_async
+import transcribe_async_gcs
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe(capsys):
-    transcribe_async.transcribe_file(os.path.join(RESOURCES, "audio.raw"))
-    out, err = capsys.readouterr()
-
-    assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)
-
-
 def test_transcribe_gcs(capsys):
-    transcribe_async.transcribe_gcs("gs://python-docs-samples-tests/speech/audio.flac")
+    transcribe_async_gcs.transcribe_gcs("gs://python-docs-samples-tests/speech/audio.flac")
     out, err = capsys.readouterr()
 
     assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)


### PR DESCRIPTION
- Refactor transcribe samples (transcribe_async) into two separate samples (transcribe_async_file and transcribe_async_gcs).
- Remove dependency on io module (use open instead of io.open).
- ~Fix small issue in argparse config for samples~ Remove CLI interface for the samples.
- Update tests.

runner.sh:
```shell
set -e

ROOT='python-speech'

pytest ${ROOT?}/samples/snippets/transcribe_async_gcs_test.py
pytest ${ROOT?}/samples/snippets/transcribe_async_file_test.py
```
