### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "speech",
     "name_pretty": "Cloud Speech",
     "product_documentation": "https://cloud.google.com/speech-to-text/docs/",
-    "client_documentation": "https://googleapis.dev/python/speech/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/speech/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559758",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ variants, to support your global user base.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-speech.svg
    :target: https://pypi.org/project/google-cloud-speech/
 .. _Cloud Speech API: https://cloud.google.com/speech
-.. _Client Library Documentation: https://googleapis.dev/python/speech/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/speech/latest
 .. _Product Documentation:  https://cloud.google.com/speech
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.