### PR TITLE
fix(deps): move libcst to extras

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,10 +17,10 @@ The 2.0.0 release requires Python 3.6+.
 
 Methods expect request objects. We provide a script that will convert most common use cases.
 
-* Install the library
+* Install the library with the `libcst` extra
 
 ```py
-python3 -m pip install google-cloud-speech
+python3 -m pip install google-cloud-speech[libcst]
 ```
 
 * The scripts `fixup_speech_v1_keywords.py` and `fixup_speech_v1p1beta1_keywords.py` are shipped with the library. It expects an input directory (with the code to convert) and an empty destination directory.

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,9 @@ dependencies = [
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566
     "google-api-core[grpc] >= 1.28.0, <3.0.0dev",
-    "libcst >= 0.2.5",
     "proto-plus >= 1.4.0",
 ]
-extras = {}
+extras = {"libcst": "libcst >= 0.2.5"}
 
 
 # Setup boilerplate below this line.


### PR DESCRIPTION
`libcst` is only needed to run the fixup script.
