### PR TITLE
Update cloud_speech.py

### DIFF
--- a/google/cloud/speech_v1/types/cloud_speech.py
+++ b/google/cloud/speech_v1/types/cloud_speech.py
@@ -554,7 +554,7 @@ class RecognitionConfig(proto.Message):
                 is supported. ``sample_rate_hertz`` must be 16000.
             WEBM_OPUS (9):
                 Opus encoded audio frames in WebM container
-                (`OggOpus <https://wiki.xiph.org/OggOpus>`__).
+                (`WebM <https://www.webmproject.org/docs/container/>`__).
                 ``sample_rate_hertz`` must be one of 8000, 12000, 16000,
                 24000, or 48000.
         """


### PR DESCRIPTION
Fixed wrong link to webm container description

Fixes googleapis/google-cloud-python#11925
